### PR TITLE
Change メニューのタブ並び順を時間通りの並びに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,34 @@
 				<p><svg class="fa fa-utensils"><use href="#fa-utensils"/></svg></p>
 				<a class="all_menu" href="#">&gt;&gt;&nbsp;成分表示つき全メニュー</a>
 				<div class="tab_wrap">
-					<input id="tab_01" type="radio" name="tab_pane" class="tab_switch" checked="checked"/><label class="tab_label label_01" for="tab_01">ランチ<span class="period">11:00-16:00</span></label>
+					<input id="tab_01" type="radio" name="tab_pane" class="tab_switch"/><label class="tab_label label_01" for="tab_01">モーニング<span class="period">7:00-11:00</span></label>
+					<div class="tab_content">
+						<div class="menu_item">
+							<p class="plate">きょうのあさごぱん</p>
+							<p class="price">550</p>
+							<p class="photo"><img src="img/lunch_01.jpg" alt="メニューの写真"></p>
+							<p>
+								日替わりパン<br>
+								＋<br>
+								ドリンク
+							</p>
+						</div>
+						<div class="menu_item">
+							<p class="plate">おこのみたまごトースト</p>
+							<p class="price">480</p>
+							<p class="photo"><img src="img/lunch_02.jpg" alt="メニューの写真"></p>
+							<p>
+								トーストの焼き加減を選ぶ<br>
+								(ふつう・こんがり)<br>
+								＋<br>
+								サイドのたまごを選ぶ<br>
+								(スクランブルエッグ・オムレツ・目玉焼き)<br>
+								＋<br>
+								ドリンク
+							</p>
+						</div>
+					</div>
+					<input id="tab_02" type="radio" name="tab_pane" class="tab_switch" checked="checked"/><label class="tab_label label_02" for="tab_02">ランチ<span class="period">11:00-16:00</span></label>
 					<div class="tab_content">
 						<div class="menu_item">
 							<p class="plate">きょうのおひるごぱん</p>
@@ -185,7 +212,7 @@
 							</p>
 						</div>
 					</div>
-					<input id="tab_02" type="radio" name="tab_pane" class="tab_switch"/><label class="tab_label label_02" for="tab_02">カフェ<span class="period">11:00-CLOSE</span></label>
+					<input id="tab_03" type="radio" name="tab_pane" class="tab_switch"/><label class="tab_label label_03" for="tab_03">カフェ<span class="period">11:00-CLOSE</span></label>
 					<div class="tab_content">
 						<div class="menu_item">
 							<p class="plate">メープルフレンチトースト</p>
@@ -201,33 +228,6 @@
 							<p class="photo"><img src="img/cafe_02.jpg" alt="メニューの写真"></p>
 							<p>
 								表面はパリパリ、中はとろとろの<br>クレームブリュレです。
-							</p>
-						</div>
-					</div>
-					<input id="tab_03" type="radio" name="tab_pane" class="tab_switch"/><label class="tab_label label_03" for="tab_03">モーニング<span class="period">7:00-11:00</span></label>
-					<div class="tab_content">
-						<div class="menu_item">
-							<p class="plate">きょうのあさごぱん</p>
-							<p class="price">550</p>
-							<p class="photo"><img src="img/lunch_01.jpg" alt="メニューの写真"></p>
-							<p>
-								日替わりパン<br>
-								＋<br>
-								ドリンク
-							</p>
-						</div>
-						<div class="menu_item">
-							<p class="plate">おこのみたまごトースト</p>
-							<p class="price">480</p>
-							<p class="photo"><img src="img/lunch_02.jpg" alt="メニューの写真"></p>
-							<p>
-								トーストの焼き加減を選ぶ<br>
-								(ふつう・こんがり)<br>
-								＋<br>
-								サイドのたまごを選ぶ<br>
-								(スクランブルエッグ・オムレツ・目玉焼き)<br>
-								＋<br>
-								ドリンク
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
メニューのタブの並び順を変更。ランチメニューが最初アクティブになってる仕様はそのまま。
変更前
ランチ/モーニング/カフェ/キッズ
↓
変更後
モーニング/ランチ/カフェ/キッズ
